### PR TITLE
fix extra unicode character

### DIFF
--- a/_sass/minimal-mistakes/vendor/susy/susy/_utilities.scss
+++ b/_sass/minimal-mistakes/vendor/susy/susy/_utilities.scss
@@ -51,7 +51,7 @@ $_susy-error-output-override: false !default;
 /// @group x-validation
 /// @access private
 ///
-/// @param {numbers} $lengths… -
+/// @param {numbers} $lengths... -
 ///   Arglist of all the number values to compare
 ///   (columns, gutters, span, etc)
 ///


### PR DESCRIPTION
The sass had a unicode character in its comments that was causing cloudflare builds to fail.  This should fix that.